### PR TITLE
Improve image loading and caching in API and Gallery

### DIFF
--- a/app/api/v1/blog/[slug]/route.ts
+++ b/app/api/v1/blog/[slug]/route.ts
@@ -26,7 +26,8 @@ export const GET = async (request: Request, context: { params: Promise<{ slug: s
     }
 
     // Try to get data from cache first
-    const cacheKey = `blog:${slug}`;
+    // Cache key version updated to v2 to invalidate old cached responses
+    const cacheKey = `blog:v2:${slug}`;
     const cachedData = await redisService.get<BlogCollectionResponse>(cacheKey);
 
     if (cachedData) {
@@ -42,7 +43,7 @@ export const GET = async (request: Request, context: { params: Promise<{ slug: s
             slug
             publishedAt
             featureImage {
-              url
+              url(transform: { width: 1 })
             }
             shortDescription
             body

--- a/app/api/v1/blog/route.ts
+++ b/app/api/v1/blog/route.ts
@@ -20,7 +20,8 @@ export const GET = async (request: Request) => {
     const skip = (page - 1) * limit;
 
     // Try to get data from cache first
-    const cacheKey = `blog:${page}:${limit}`;
+    // Cache key version updated to v2 to invalidate old cached responses
+    const cacheKey = `blog:v2:${page}:${limit}`;
     const cachedData = await redisService.get<BlogCollectionResponse>(cacheKey);
 
     if (cachedData) {
@@ -38,7 +39,7 @@ export const GET = async (request: Request) => {
             slug
             publishedAt
             featureImage {
-              url
+              url(transform: { width: 1 })
             }
             body
             tags

--- a/app/api/v1/collections/[slug]/[page]/route.ts
+++ b/app/api/v1/collections/[slug]/[page]/route.ts
@@ -21,7 +21,8 @@ export const GET = async (
     const pageNumber = parseInt(page, 10);
 
     // Try to get data from cache first
-    const cacheKey = `collections:${slug}:${pageNumber}`;
+    // Cache key version updated to v2 to invalidate old cached responses
+    const cacheKey = `collections:v2:${slug}:${pageNumber}`;
     const cachedData = await redisService.get<GalleryCollectionResponse>(cacheKey);
 
     if (cachedData) {
@@ -52,7 +53,7 @@ export const GET = async (
               year
               overrideImageLinks
               coverImage {
-                url
+                url(transform: { width: 1 })
               }
             }
             gallery {
@@ -64,7 +65,7 @@ export const GET = async (
                 items {
                   title
                   description
-                  url
+                  url(transform: { width: 1 })
                 }
               }
             }

--- a/app/api/v1/pages/route.ts
+++ b/app/api/v1/pages/route.ts
@@ -28,7 +28,8 @@ export const GET = async (request: Request) => {
     }
 
     // Try to get data from cache first
-    const cacheKey = `pages:${slug}`;
+    // Cache key version updated to v2 to invalidate old cached responses
+    const cacheKey = `pages:v2:${slug}`;
     const cachedData = await redisService.get<PageCollectionResponse>(cacheKey);
 
     if (cachedData) {
@@ -56,14 +57,14 @@ export const GET = async (request: Request) => {
                 description
                 overrideImageLinks
                 coverImage {
-                  url
+                  url(transform: { width: 1 })
                 }
                 gallery {
                   imagesCollection(limit: $limit) {
                     items {
                       title
                       description
-                      url
+                      url(transform: { width: 1 })
                     }
                   }
                 }

--- a/app/components/ImageModal/ImageModal.module.css
+++ b/app/components/ImageModal/ImageModal.module.css
@@ -87,6 +87,14 @@
   object-fit: contain;
 }
 
+.lowQuality {
+  position: absolute;
+  top: 1.25rem;
+  left: 1.25rem;
+  right: 1.25rem;
+  bottom: 1.25rem;
+}
+
 .caption {
   position: absolute;
   bottom: 0;

--- a/lib/utils/images.utils.ts
+++ b/lib/utils/images.utils.ts
@@ -1,10 +1,32 @@
 import { normalizeUrl } from "./url.utils";
 
+/**
+ * Normalizes Contentful URLs to use the Images API domain
+ * Converts downloads.ctfassets.net to images.ctfassets.net for API optimization
+ *
+ * This is a safety fallback layer. All GraphQL queries use url(transform: { width: 1 })
+ * to request images.ctfassets.net URLs from Contentful, but this ensures any edge cases
+ * or cached data with downloads URLs are still handled correctly.
+ *
+ * @param url - The original Contentful URL
+ * @returns Normalized URL using images.ctfassets.net
+ */
+const normalizeContentfulUrl = (url: string): string => {
+  if (!url) return "";
+
+  // Replace downloads.ctfassets.net with images.ctfassets.net
+  // This ensures all images can use Contentful's Image API
+  return url.replace("downloads.ctfassets.net", "images.ctfassets.net");
+};
+
 export const getContentfulImage = (imageUrl: string, config?: ImageConfig): string => {
   if (!imageUrl) return "";
 
   // Normalize URL with https protocol if needed
-  const baseUrl = normalizeUrl(imageUrl);
+  let baseUrl = normalizeUrl(imageUrl);
+
+  // Ensure we're using images.ctfassets.net for API optimization
+  baseUrl = normalizeContentfulUrl(baseUrl);
 
   // If no config, return the base URL
   if (!config) return baseUrl;


### PR DESCRIPTION
Updated API routes to use versioned cache keys (v2) to invalidate old cached responses and request transformed image URLs for optimization. Enhanced Gallery and ImageModal components to preload adjacent modal images and implement progressive image loading with low-quality placeholders. Added normalization of Contentful image URLs to ensure use of the Images API for all image requests.