### PR TITLE
feat: redesign homepage with immersive hero and marquee

### DIFF
--- a/app/HomePage.tsx
+++ b/app/HomePage.tsx
@@ -1,51 +1,63 @@
 import { ReactElement, Fragment } from "react";
 
 /* Components */
-import HeroBanner from "./components/HeroBanner/HeroBanner";
+import HomeHero from "./components/HomeHero/HomeHero";
 import Gallery from "./components/Gallery/Gallery";
 import SectionTitle from "./components/SectionTitle/SectionTitle";
+import ImageMarquee from "./components/ImageMarquee/ImageMarquee";
 
 /* Utils */
 import { getGalleryPath } from "@/lib/utils/url.utils";
+import { getMarqueeImages } from "@/lib/utils/gallery.utils";
 
 type HomePageProps = {
   collections: GalleryCollectionItem[];
 };
 
 const HomePage = ({ collections }: HomePageProps): ReactElement => {
-  const [head, ...tail] = collections;
+  const [hero, ...tail] = collections;
+  const marqueeImages = getMarqueeImages(collections);
 
   return (
-    <Fragment>
-      <HeroBanner
-        heroImage={head.coverImage.url}
-        title={head.title}
-        year={head.year.toString()}
-        description={head.description}
-        link={head?.slug ? getGalleryPath(head.slug) : null}
+    <>
+      {/* Full-screen immersive hero */}
+      <HomeHero
+        heroImage={hero.coverImage.url}
+        title={hero.title}
+        year={hero.year.toString()}
+        description={hero.description}
+        link={hero.slug ? getGalleryPath(hero.slug) : null}
       />
 
-      {tail?.length > 0 &&
-        tail.map((item, index) => (
-          <Fragment key={`${item.slug}-${index + 1}`}>
-            <SectionTitle
-              title={item.title}
-              description={item.subtitle}
-              link={item.slug ? getGalleryPath(item.slug) : null}
-            />
+      {/* Marquee right under the hero */}
+      {marqueeImages.length > 4 && <ImageMarquee images={marqueeImages} />}
 
-            <Gallery
-              images={item.gallery.imagesCollection.items.slice(
-                0,
-                !item?.overrideImageLinks ? 20 : 8
-              )}
-              overrideImageLinks={item?.overrideImageLinks}
-              hideTitle={!item?.overrideImageLinks}
-              masonry={!item?.overrideImageLinks}
-            />
-          </Fragment>
-        ))}
-    </Fragment>
+      {/* Collection sections */}
+      <div className="container">
+        {tail?.length > 0 &&
+          tail.map((item, index) => {
+            const imageLimit = !item?.overrideImageLinks ? 20 : 8;
+            const galleryImages = item.gallery.imagesCollection.items.slice(0, imageLimit);
+
+            return (
+              <Fragment key={`${item.slug}-${index + 1}`}>
+                <SectionTitle
+                  title={item.title}
+                  description={item.subtitle}
+                  link={item.slug ? getGalleryPath(item.slug) : null}
+                />
+
+                <Gallery
+                  images={galleryImages}
+                  overrideImageLinks={item?.overrideImageLinks}
+                  hideTitle={!item?.overrideImageLinks}
+                  masonry={!item?.overrideImageLinks}
+                />
+              </Fragment>
+            );
+          })}
+      </div>
+    </>
   );
 };
 

--- a/app/components/HomeHero/HomeHero.module.css
+++ b/app/components/HomeHero/HomeHero.module.css
@@ -1,0 +1,208 @@
+.hero {
+  position: relative;
+  width: 100%;
+  height: 100svh;
+  min-height: 32rem;
+  overflow: hidden;
+  background: var(--color-black);
+}
+
+/* Image layers (LQIP blur-to-sharp) */
+.imageWrapper {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.imageLqip {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(1.25rem);
+  transform: scale(1.1);
+}
+
+.imageHq {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  animation: heroZoomIn 1.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+
+.imageLoaded {
+  opacity: 1;
+}
+
+@keyframes heroZoomIn {
+  from {
+    transform: scale(1.08);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+/* Parallax via scroll-driven animation */
+@supports (animation-timeline: scroll()) {
+  .imageWrapper {
+    animation: heroParallax linear forwards;
+    animation-timeline: scroll();
+    animation-range: 0vh 100vh;
+  }
+
+  @keyframes heroParallax {
+    to {
+      transform: translateY(15%);
+    }
+  }
+}
+
+/* Gradient overlay */
+.overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background:
+    linear-gradient(to top, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.15) 50%, transparent 100%),
+    linear-gradient(to right, rgba(0, 0, 0, 0.3) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+/* Content */
+.content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  padding: 4rem 4rem 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.title {
+  font-size: clamp(3.2rem, 7vw, 7.2rem);
+  font-weight: var(--font-extrabold);
+  line-height: 0.95;
+  color: var(--color-white);
+  letter-spacing: -0.03em;
+  margin: 0;
+  animation: revealUp 0.9s cubic-bezier(0.16, 1, 0.3, 1) 0.2s both;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  animation: revealUp 0.9s cubic-bezier(0.16, 1, 0.3, 1) 0.4s both;
+}
+
+.year {
+  font-family: var(--font-secondary);
+  font-size: var(--text-sm);
+  color: var(--color-orange);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  font-weight: var(--font-bold);
+}
+
+.divider {
+  width: 3rem;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.description {
+  font-size: var(--text-base);
+  color: rgba(255, 255, 255, 0.75);
+  max-width: 36ch;
+  margin: 0;
+  font-weight: var(--font-light);
+  line-height: var(--leading-relaxed);
+}
+
+.heroLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-white);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-top: 0.5rem;
+  animation: revealUp 0.9s cubic-bezier(0.16, 1, 0.3, 1) 0.6s both;
+  transition: gap 0.3s ease;
+}
+
+.heroLink:hover {
+  gap: 1rem;
+}
+
+.heroLinkArrow {
+  transition: transform 0.3s ease;
+}
+
+.heroLink:hover .heroLinkArrow {
+  transform: translateX(0.25rem);
+}
+
+/* Scroll indicator — override Loading component's fixed positioning */
+.scrollIndicator {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  animation: revealUp 0.9s cubic-bezier(0.16, 1, 0.3, 1) 0.8s both;
+}
+
+.scrollIndicator > div {
+  position: static;
+  opacity: 0.86;
+}
+
+@keyframes revealUp {
+  from {
+    opacity: 0;
+    transform: translateY(2.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .hero {
+    height: 100svh;
+    min-height: 28rem;
+  }
+
+  .content {
+    padding: 2rem 2rem 5rem;
+  }
+
+  .title {
+    font-size: clamp(2.8rem, 10vw, 4.8rem);
+  }
+
+  .description {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .content {
+    padding: 1.5rem 1.5rem 5rem;
+  }
+}

--- a/app/components/HomeHero/HomeHero.tsx
+++ b/app/components/HomeHero/HomeHero.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { ReactElement, useState, useEffect } from "react";
+import Link from "next/link";
+
+/* Components */
+import Loading from "../Loading/Loading";
+
+/* Constants */
+import { HeroImageConfig, LowQualityImageConfig } from "@/lib/constants/images.constants";
+
+/* Utils */
+import { isClient } from "@/lib/utils/ui.utils";
+import { getContentfulImage } from "@/lib/utils/images.utils";
+
+/* Styles */
+import styles from "./HomeHero.module.css";
+
+type HomeHeroProps = {
+  heroImage: string;
+  link: string | null;
+  title: string;
+  year: string;
+  description: string;
+};
+
+const HomeHero = ({ heroImage, title, year, description, link }: HomeHeroProps): ReactElement => {
+  const [isHqLoaded, setIsHqLoaded] = useState(false);
+
+  const lqipUrl = getContentfulImage(heroImage, LowQualityImageConfig);
+  const hqUrl = getContentfulImage(heroImage, HeroImageConfig);
+
+  useEffect(() => {
+    if (isClient()) {
+      const img = new window.Image();
+      img.src = hqUrl;
+      img.onload = (): void => setIsHqLoaded(true);
+    }
+  }, [hqUrl]);
+
+  return (
+    <section className={styles.hero}>
+      {/* Image layers: LQIP + HQ */}
+      <div className={styles.imageWrapper}>
+        <img className={styles.imageLqip} src={lqipUrl} alt="" aria-hidden="true" />
+        <img
+          className={`${styles.imageHq} ${isHqLoaded ? styles.imageLoaded : ""}`}
+          src={hqUrl}
+          alt={title}
+        />
+      </div>
+
+      {/* Gradient overlay */}
+      <div className={styles.overlay} />
+
+      {/* Text content */}
+      <div className={styles.content}>
+        <h1 className={styles.title}>{title}</h1>
+
+        <div className={styles.meta}>
+          <span className={styles.year}>{year}</span>
+          <span className={styles.divider} />
+          <p className={styles.description}>{description}</p>
+        </div>
+
+        {link && (
+          <Link href={link} className={styles.heroLink}>
+            Explore Collection
+            <span className={styles.heroLinkArrow}>&rarr;</span>
+          </Link>
+        )}
+      </div>
+
+      {/* Scroll indicator */}
+      <div className={styles.scrollIndicator}>
+        <Loading />
+      </div>
+    </section>
+  );
+};
+
+export default HomeHero;

--- a/app/components/ImageMarquee/ImageMarquee.module.css
+++ b/app/components/ImageMarquee/ImageMarquee.module.css
@@ -1,0 +1,83 @@
+.section {
+  padding: 0;
+  overflow: hidden;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 20rem;
+}
+
+.label {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--color-grey-500);
+  margin-bottom: 1.5rem;
+  padding: 0 2rem;
+}
+
+.marquee {
+  mask-image: linear-gradient(to right, transparent 0%, black 5%, black 95%, transparent 100%);
+}
+
+.track {
+  display: flex;
+  gap: 0.375rem;
+  width: max-content;
+  animation: marqueeScroll 40s linear infinite;
+  will-change: transform;
+}
+
+.track:hover {
+  animation-play-state: paused;
+}
+
+.imageWrapper {
+  flex-shrink: 0;
+  overflow: hidden;
+  height: 14rem;
+  position: relative;
+  cursor: pointer;
+}
+
+.image {
+  height: 100%;
+  width: auto;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.5s ease;
+}
+
+.imageWrapper:hover .image {
+  transform: scale(1.05);
+}
+
+@keyframes marqueeScroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .section {
+    padding: 0;
+  }
+
+  .imageWrapper {
+    height: 10rem;
+  }
+
+  .track {
+    animation-duration: 30s;
+  }
+}
+
+/* Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  .track {
+    animation-play-state: paused;
+  }
+}

--- a/app/components/ImageMarquee/ImageMarquee.tsx
+++ b/app/components/ImageMarquee/ImageMarquee.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ReactElement, useState } from "react";
+import { createPortal } from "react-dom";
+
+/* Components */
+import ImageModal from "../ImageModal/ImageModal";
+
+/* Constants */
+import { MediumQualityImageConfig, ModalImageConfig } from "@/lib/constants/images.constants";
+
+/* Utils */
+import { getContentfulImage } from "@/lib/utils/images.utils";
+import { isClient } from "@/lib/utils/ui.utils";
+
+/* Styles */
+import styles from "./ImageMarquee.module.css";
+
+type ImageMarqueeProps = {
+  images: MarqueeImage[];
+};
+
+const ImageMarquee = ({ images }: ImageMarqueeProps): ReactElement => {
+  const [selectedImage, setSelectedImage] = useState<MarqueeImage | null>(null);
+
+  // Duplicate images for seamless loop
+  const duplicated = [...images, ...images];
+
+  const handleImageClick = (image: MarqueeImage): void => {
+    setSelectedImage(image);
+  };
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.marquee}>
+        <div className={styles.track}>
+          {duplicated.map((image, index) => (
+            <div
+              key={`marquee-${index}`}
+              className={styles.imageWrapper}
+              onClick={() => handleImageClick(image)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleImageClick(image);
+              }}
+            >
+              <img
+                className={styles.image}
+                src={getContentfulImage(image.url, MediumQualityImageConfig)}
+                alt={image.title || "Gallery photo"}
+                loading="lazy"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {selectedImage &&
+        isClient() &&
+        createPortal(
+          <ImageModal
+            isOpen={!!selectedImage}
+            onClose={() => setSelectedImage(null)}
+            image={selectedImage}
+            imageConfig={ModalImageConfig}
+          />,
+          document.body
+        )}
+    </section>
+  );
+};
+
+export default ImageMarquee;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -125,7 +125,7 @@ const Page = async (): Promise<ReactElement> => {
   }
 
   return (
-    <main className="container container-padding-lg">
+    <main>
       <HomePage collections={pageData.collectionsCollection.items ?? []} />
     </main>
   );

--- a/lib/constants/images.constants.ts
+++ b/lib/constants/images.constants.ts
@@ -19,6 +19,13 @@ export const HeroImageConfig: ImageConfig = {
   q: 90,
 };
 
+export const MediumQualityImageConfig: ImageConfig = {
+  fit: "thumb",
+  h: 400,
+  f: "center",
+  q: 75,
+};
+
 export const LowQualityImageConfig: ImageConfig = {
   fit: "thumb",
   h: 400,

--- a/lib/utils/gallery.utils.ts
+++ b/lib/utils/gallery.utils.ts
@@ -1,0 +1,11 @@
+export const getMarqueeImages = (
+  collections: GalleryCollectionItem[],
+  maxPerCollection: number = 6
+): MarqueeImage[] => {
+  return collections.flatMap((collection) =>
+    collection.gallery.imagesCollection.items.slice(0, maxPerCollection).map((image) => ({
+      title: image.title,
+      url: image.url,
+    }))
+  );
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
+    formats: ["image/avif", "image/webp"],
     remotePatterns: [
       {
         protocol: "https",

--- a/types/gallery.d.ts
+++ b/types/gallery.d.ts
@@ -1,1 +1,6 @@
 // Gallery types are defined in contentful.d.ts (GalleryItem, GalleryCollectionItem)
+
+interface MarqueeImage {
+  title: string;
+  url: string;
+}


### PR DESCRIPTION
## Summary
- Full-screen **HomeHero** with LQIP blur-to-sharp image loading, CSS scroll-driven parallax, cinematic typography reveal animations, and mouse-scroll indicator
- **ImageMarquee** with CSS-only infinite horizontal scroll, edge fade masks, hover pause, and click-to-open ImageModal (via React portal)
- Restructured homepage layout: Hero → Marquee → Collection sections (SectionTitle + Gallery with existing masonry/grid behavior)
- Added AVIF/WebP image format support in `next.config.mjs`
- Extracted `getMarqueeImages` utility and `MarqueeImage` type to proper locations

## Test plan
- [ ] Verify hero loads with blur placeholder, then sharpens smoothly
- [ ] Verify parallax scroll effect on hero (Chrome/Edge)
- [ ] Verify marquee auto-scrolls, pauses on hover, opens modal on click
- [ ] Verify collection sections render with correct masonry/grid layouts
- [ ] Test on mobile viewport (hero responsive, marquee scales)
- [ ] Verify build passes with zero errors