### PR TITLE
fix: mobile homepage navbar overlay and hero cleanup

### DIFF
--- a/app/components/HomeHero/HomeHero.module.css
+++ b/app/components/HomeHero/HomeHero.module.css
@@ -196,6 +196,10 @@
     font-size: clamp(2.8rem, 10vw, 4.8rem);
   }
 
+  .divider {
+    display: none;
+  }
+
   .description {
     display: none;
   }

--- a/app/components/Navbar/Navbar.module.css
+++ b/app/components/Navbar/Navbar.module.css
@@ -34,4 +34,8 @@
     justify-content: center;
     position: relative;
   }
+
+  :global(body:has(main[data-page="home"])) .navbar {
+    position: absolute;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -125,7 +125,7 @@ const Page = async (): Promise<ReactElement> => {
   }
 
   return (
-    <main>
+    <main data-page="home">
       <HomePage collections={pageData.collectionsCollection.items ?? []} />
     </main>
   );


### PR DESCRIPTION
## Summary
- Navbar now overlays the hero on mobile (position absolute) only on the homepage, using `data-page="home"` attribute and CSS `:has()` selector
- Hidden divider and description in the hero section on mobile viewports

## Test plan
- [ ] Verify navbar overlays hero on mobile homepage
- [ ] Verify navbar remains `position: relative` on mobile for other pages (blog, about, gallery)
- [ ] Verify divider between year and description is hidden on mobile
- [ ] Verify desktop layout is unchanged